### PR TITLE
ci: update base image for book workflow

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
`ubuntu-18.04` image is getting deprecated pretty soon. I got here by searching for the image name across PL related orgs. 